### PR TITLE
fix: update release workflow to use PAT for branch protection bypass

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -70,6 +72,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          token: ${{ secrets.RELEASE_TOKEN }}
           tag_name: v${{ github.event.inputs.release_version }}
           name: Release ${{ github.event.inputs.release_version }}
           draft: false


### PR DESCRIPTION
## Summary

This PR updates the prepare-release workflow to use a Personal Access Token (PAT) to bypass branch protection rules when pushing release commits and tags.

## Problem
The release workflow was failing with:
- "Repository rule violations found for refs/heads/main"
- "Changes must be made through a pull request"

## Solution
- Modified the workflow to use a PAT (stored as `RELEASE_TOKEN` secret) instead of the default `GITHUB_TOKEN`
- The PAT needs to be created with `repo` and `workflow` scopes
- Updated both the checkout step and the release creation step to use the token

## Setup Required
Before running the release workflow again:
1. Create a Personal Access Token with `repo` and `workflow` scopes
2. Add it as a repository secret named `RELEASE_TOKEN`
3. The PAT should be from a user account that has permission to bypass branch protection

## Testing
Once this is merged and the PAT is configured, the prepare-release workflow should be able to:
- Push version update commits directly to main
- Push tags
- Create GitHub releases

🤖 Generated with [Claude Code](https://claude.ai/code)