### PR TITLE
feat: update release workflow to use PRs for protected main branch

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     
     steps:
       - name: Checkout code
@@ -48,9 +49,6 @@ jobs:
           git add build.gradle
           git commit -m "chore: prepare release ${{ github.event.inputs.release_version }}"
 
-      - name: Create release tag
-        run: git tag -a v${{ github.event.inputs.release_version }} -m "Release ${{ github.event.inputs.release_version }}"
-
       - name: Update to next development version
         run: |
           NEXT_VERSION="${{ github.event.inputs.next_version }}"
@@ -62,16 +60,20 @@ jobs:
           git add build.gradle
           git commit -m "chore: prepare for next development version ${{ github.event.inputs.next_version }}"
 
-      - name: Push changes
-        run: |
-          git push
-          git push --tags
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
         with:
-          tag_name: v${{ github.event.inputs.release_version }}
-          name: Release ${{ github.event.inputs.release_version }}
-          draft: false
-          prerelease: false
-          generate_release_notes: true
+          branch: release/${{ github.event.inputs.release_version }}
+          title: "Release: ${{ github.event.inputs.release_version }}"
+          body: |
+            ## Release ${{ github.event.inputs.release_version }}
+            
+            This PR prepares the release for version ${{ github.event.inputs.release_version }} and sets up the next development version ${{ github.event.inputs.next_version }}.
+            
+            ### Changes
+            - Update version to ${{ github.event.inputs.release_version }}
+            - Update version to next development version ${{ github.event.inputs.next_version }}
+            
+            Once this PR is merged, a tag `v${{ github.event.inputs.release_version }}` will be created automatically and a GitHub release will be published.
+          labels: release
+          delete-branch: true

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,75 @@
+name: Tag and Release
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  tag-release:
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Configure Git
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+
+      - name: Extract version from PR title
+        id: extract_version
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          VERSION=$(echo "$PR_TITLE" | sed -n 's/Release: \(.*\)/\1/p')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION"
+
+      - name: Read current version from build.gradle
+        id: read_version
+        run: |
+          CURRENT_VERSION=$(grep "version = " build.gradle | sed -n "s/version = '\(.*\)'/\1/p")
+          echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          echo "Current version in build.gradle: $CURRENT_VERSION"
+
+      - name: Find release commit
+        id: find_commit
+        run: |
+          RELEASE_VERSION="${{ steps.extract_version.outputs.version }}"
+          # Find the commit that updated to the release version
+          RELEASE_COMMIT=$(git log --format="%H %s" -n 50 | grep "chore: prepare release $RELEASE_VERSION" | cut -d' ' -f1)
+          if [ -z "$RELEASE_COMMIT" ]; then
+            echo "Could not find release commit for version $RELEASE_VERSION"
+            exit 1
+          fi
+          echo "commit=$RELEASE_COMMIT" >> $GITHUB_OUTPUT
+          echo "Found release commit: $RELEASE_COMMIT"
+
+      - name: Create release tag
+        run: |
+          RELEASE_VERSION="${{ steps.extract_version.outputs.version }}"
+          RELEASE_COMMIT="${{ steps.find_commit.outputs.commit }}"
+          git tag -a "v$RELEASE_VERSION" "$RELEASE_COMMIT" -m "Release $RELEASE_VERSION"
+          git push origin "v$RELEASE_VERSION"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.extract_version.outputs.version }}
+          name: Release ${{ steps.extract_version.outputs.version }}
+          draft: false
+          prerelease: false
+          generate_release_notes: true

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -47,18 +47,22 @@ Add the following secrets to your GitHub repository:
 5. Click "Run workflow" to start the release process
 
 The workflow will automatically:
-1. Update the version in build.gradle to the release version
-2. Build and test the project with the release version
-3. Commit the release version change
-4. Create a Git tag for the release
+1. Create a new branch named `release/{version}`
+2. Update the version in build.gradle to the release version
+3. Build and test the project with the release version
+4. Commit the release version change
 5. Update the version in build.gradle to the next development version
 6. Commit the next development version change
-7. Push all changes and tags to GitHub
-8. Create a GitHub Release
-9. Trigger the "Publish to Maven Central" workflow that will:
-   - Build the project
-   - Sign the artifacts
-   - Publish directly to Maven Central using the User Token
+7. Create a pull request to the main branch with the label "release"
+8. Once the PR is merged, a separate workflow will:
+   - Create a Git tag for the release on the appropriate commit
+   - Create a GitHub Release
+   - Trigger the "Publish to Maven Central" workflow that will:
+     - Build the project
+     - Sign the artifacts
+     - Publish directly to Maven Central using the User Token
+
+**Note**: Since the main branch is protected, the release process uses pull requests to ensure all changes are reviewed before being merged.
 
 ### Manual Release Process (Alternative)
 


### PR DESCRIPTION
## Summary
- Modified `prepare-release.yml` to create PR instead of direct commits to main
- Added new `tag-release.yml` workflow that triggers when release PRs are merged
- Updated release process documentation to reflect the new workflow

## Changes
1. **prepare-release.yml**:
   - Removed direct commits and pushes to main branch
   - Uses `peter-evans/create-pull-request@v7` action to create a PR
   - Creates a branch named `release/{version}`
   - Both version updates (release and next development) are included in the PR
   - PR is labeled with "release" for easy identification

2. **tag-release.yml** (new):
   - Triggers when a PR with the "release" label is merged
   - Extracts version from PR title
   - Finds the specific release commit (not the merge commit)
   - Creates the tag on the correct commit
   - Creates the GitHub release

3. **docs/release_process.md**:
   - Updated documentation to reflect the new PR-based workflow
   - Added note about protected branches

## How It Works
1. Developer runs "Prepare Release" workflow with version numbers
2. Workflow creates a PR with both version changes
3. PR gets reviewed and merged (following branch protection rules)
4. "Tag and Release" workflow automatically triggers on merge
5. Tag is created on the release commit and GitHub release is published
6. Existing publish workflow triggers on the new release

This approach ensures compliance with branch protection while maintaining automation of the release process.

🤖 Generated with [Claude Code](https://claude.ai/code)