### PR TITLE
fix: add PAT support for release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -63,6 +65,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.RELEASE_TOKEN }}
           branch: release/${{ github.event.inputs.release_version }}
           title: "Release: ${{ github.event.inputs.release_version }}"
           body: |

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -33,6 +33,18 @@ Add the following secrets to your GitHub repository:
 2. `MAVEN_CENTRAL_TOKEN`: Your Maven Central Portal User Token
 3. `SIGNING_KEY`: The contents of your exported private key (the entire file content)
 4. `SIGNING_KEY_PASSWORD`: The passphrase for your GPG key
+5. `RELEASE_TOKEN`: A GitHub Personal Access Token (PAT) with `repo` and `pull_request` permissions (required for creating pull requests)
+
+### Creating a GitHub Personal Access Token for Releases
+
+1. Go to GitHub Settings > Developer settings > Personal access tokens > Tokens (classic)
+2. Click "Generate new token (classic)"
+3. Give it a descriptive name like "JavaFlow Release Automation"
+4. Select the following scopes:
+   - `repo` (all permissions under repo)
+   - `workflow` (to trigger workflows)
+5. Click "Generate token" and copy the token
+6. Add it as a repository secret named `RELEASE_TOKEN`
 
 ## Release Process
 


### PR DESCRIPTION
## Summary
- Add `RELEASE_TOKEN` to checkout and PR creation steps in prepare-release.yml
- Update documentation with PAT creation instructions

## Problem
The default `GITHUB_TOKEN` provided to GitHub Actions doesn't have permission to create pull requests, resulting in the error:
```
Error: GitHub Actions is not permitted to create or approve pull requests.
```

## Solution
Use a Personal Access Token (PAT) with appropriate permissions:
1. The workflow now uses `${{ secrets.RELEASE_TOKEN }}` for checkout and PR creation
2. Documentation updated with instructions on how to create the PAT

## Setup Required
Before using the release workflow, you need to:
1. Create a GitHub PAT with `repo` and `workflow` permissions
2. Add it as a repository secret named `RELEASE_TOKEN`

🤖 Generated with [Claude Code](https://claude.ai/code)