### PR TITLE
fix: use GitHub CLI for creating release PRs

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -36,6 +36,8 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
+          # Configure git to use the token for authentication
+          git config --local http.https://github.com/.extraheader "AUTHORIZATION: bearer ${{ secrets.RELEASE_TOKEN }}"
 
       - name: Update to release version
         run: |
@@ -62,14 +64,19 @@ jobs:
           git add build.gradle
           git commit -m "chore: prepare for next development version ${{ github.event.inputs.next_version }}"
 
+      - name: Create and push release branch
+        run: |
+          BRANCH_NAME="release/${{ github.event.inputs.release_version }}"
+          git checkout -b "$BRANCH_NAME"
+          git push -u origin "$BRANCH_NAME"
+
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ secrets.RELEASE_TOKEN }}
-          branch: release/${{ github.event.inputs.release_version }}
-          title: "Release: ${{ github.event.inputs.release_version }}"
-          body: |
-            ## Release ${{ github.event.inputs.release_version }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          gh pr create \
+            --title "Release: ${{ github.event.inputs.release_version }}" \
+            --body "## Release ${{ github.event.inputs.release_version }}
             
             This PR prepares the release for version ${{ github.event.inputs.release_version }} and sets up the next development version ${{ github.event.inputs.next_version }}.
             
@@ -77,6 +84,5 @@ jobs:
             - Update version to ${{ github.event.inputs.release_version }}
             - Update version to next development version ${{ github.event.inputs.next_version }}
             
-            Once this PR is merged, a tag `v${{ github.event.inputs.release_version }}` will be created automatically and a GitHub release will be published.
-          labels: release
-          delete-branch: true
+            Once this PR is merged, a tag \`v${{ github.event.inputs.release_version }}\` will be created automatically and a GitHub release will be published." \
+            --label "release"


### PR DESCRIPTION
## Summary
- Replace `peter-evans/create-pull-request` action with direct git push and GitHub CLI
- Add proper git authentication configuration for the PAT

## Problem
The `peter-evans/create-pull-request` action was failing with a 403 error:
```
remote: Permission to panghy/javaflow.git denied to panghy.
fatal: unable to access 'https://github.com/panghy/javaflow/': The requested URL returned error: 403
```

## Solution
1. Use manual git commands to create and push the release branch
2. Use the GitHub CLI (`gh`) to create the pull request
3. Configure git authentication header to use the PAT

This approach gives us more control and better compatibility with PATs.

## Testing
After this PR is merged, the release workflow should:
1. Create a new branch `release/{version}`
2. Push it to the repository using the PAT
3. Create a PR using the GitHub CLI

🤖 Generated with [Claude Code](https://claude.ai/code)