### PR TITLE
fix: persist git credentials for release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -36,8 +36,8 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          # Configure git to use the token for authentication
-          git config --local http.https://github.com/.extraheader "AUTHORIZATION: bearer ${{ secrets.RELEASE_TOKEN }}"
+          # Set the remote URL to use the token
+          git remote set-url origin https://x-access-token:${{ secrets.RELEASE_TOKEN }}@github.com/${{ github.repository }}.git
 
       - name: Update to release version
         run: |
@@ -67,6 +67,8 @@ jobs:
       - name: Create and push release branch
         run: |
           BRANCH_NAME="release/${{ github.event.inputs.release_version }}"
+          # Delete the branch if it already exists (from a previous failed run)
+          git push origin --delete "$BRANCH_NAME" || true
           git checkout -b "$BRANCH_NAME"
           git push -u origin "$BRANCH_NAME"
 


### PR DESCRIPTION
## Summary
- Explicitly set remote URL with token after checkout
- Handle case where release branch already exists from failed runs

## Problem
Even with token in checkout, git push was failing with:
```
fatal: could not read Username for 'https://github.com': No such device or address
```

## Solution
1. After checkout, explicitly set the remote URL to include the token
2. Delete existing release branch if it exists (from previous failed runs)
3. This ensures git push works properly with the PAT

The checkout action with token doesn't always persist credentials properly for push operations, so we need to explicitly set the remote URL with the token.

## Testing
After this PR is merged, the release workflow should:
1. Checkout with the PAT token
2. Set remote URL to include the token
3. Delete existing release branch if present
4. Create and push the new release branch successfully

🤖 Generated with [Claude Code](https://claude.ai/code)