### PR TITLE
fix: debug and fix git authentication in release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -34,10 +32,17 @@ jobs:
 
       - name: Configure Git and Authentication
         run: |
-          # Set the remote URL to use the token FIRST
+          # Debug: Check if token is available
+          if [ -z "${{ secrets.RELEASE_TOKEN }}" ]; then
+            echo "ERROR: RELEASE_TOKEN is not set!"
+            exit 1
+          fi
+          # Set the remote URL to use the token
           git remote set-url origin https://x-access-token:${{ secrets.RELEASE_TOKEN }}@github.com/${{ github.repository }}.git
-          # Verify the remote URL is set (will show the URL with token masked)
-          echo "Remote URL configured"
+          # Verify the remote URL is set
+          echo "Remote URL configured successfully"
+          # Test authentication with a simple fetch
+          git fetch origin || echo "WARNING: Fetch failed"
           # Configure git user
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"


### PR DESCRIPTION
## Summary
- Remove token from checkout action to avoid conflicts
- Add debugging to verify token availability
- Test authentication with git fetch before attempting push
- Manually configure remote URL after standard checkout

## Problem
Even with the remote URL being set, git push was still failing with 403 errors. The logs showed the URL was being masked (***github.com) but push operations were still failing.

## Hypothesis
Using `token` in the checkout action might be creating a conflict with our manual remote URL setting. The checkout action might be configuring git in a way that overrides our subsequent configuration.

## Solution
1. Do a standard checkout without token
2. Manually set the remote URL with the PAT
3. Add debugging to ensure token is available
4. Test authentication with `git fetch` before attempting push

This approach gives us full control over the git configuration.

🤖 Generated with [Claude Code](https://claude.ai/code)