### PR TITLE
fix: remove release label requirement from workflows

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -89,5 +89,4 @@ jobs:
             - Update version to ${{ github.event.inputs.release_version }}
             - Update version to next development version ${{ github.event.inputs.next_version }}
             
-            Once this PR is merged, a tag \`v${{ github.event.inputs.release_version }}\` will be created automatically and a GitHub release will be published." \
-            --label "release"
+            Once this PR is merged, a tag \`v${{ github.event.inputs.release_version }}\` will be created automatically and a GitHub release will be published."

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   tag-release:
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, 'Release:')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Remove `--label "release"` from PR creation command
- Change tag-release workflow to trigger on PR title pattern instead of label

## Problem
The workflow succeeded in pushing the branch but failed with:
```
could not add label: 'release' not found
```

## Solution
1. Remove the label requirement from `gh pr create` command
2. Update `tag-release.yml` to trigger based on PR title starting with "Release:" instead of label

This is more reliable since we control the PR title format but labels need to be pre-created in the repository.

## Good News
The authentication fix worked perfectly\! The workflow successfully:
- ✅ Deleted the existing branch
- ✅ Created a new branch
- ✅ Pushed to origin

The only failure was the missing label.

🤖 Generated with [Claude Code](https://claude.ai/code)